### PR TITLE
Fix incompatble Matlab syntaxes for handling indices and inlined vectors calculations.

### DIFF
--- a/matlab/src/optm_inner.m
+++ b/matlab/src/optm_inner.m
@@ -6,8 +6,8 @@
 %% If `x` and `y` are the same, it is more efficient to call `optm_norm2(x)^2`.
 function s = optm_inner(x, y)
     %%s = x(:)'*y(:); % <-- the fastest when x and y are not the same
-    %%s = sum(x(:).*y(:));
+    s = sum(x(:).*y(:));
     %%s = sum(bsxfun(@times, x(:), y(:)));
-    s = sum((x.*y)(:));
+    %%s = sum((x.*y)(:));
     %%s = sum(bsxfun(@times, x, y)(:));
 end

--- a/matlab/src/optm_line_search_limits.m
+++ b/matlab/src/optm_line_search_limits.m
@@ -52,7 +52,7 @@ function [amin, amax] = optm_line_search_limits(x0, xmin, xmax, pm, d)
                 amax = INF;
             else
                 i = d > 0;
-                a = (x0 - xmin)(i) ./ d(i);
+                a = (x0(i) - xmin(i)) ./ d(i);
                 amin = min(a);
                 amax = max(a);
             end
@@ -63,7 +63,7 @@ function [amin, amax] = optm_line_search_limits(x0, xmin, xmax, pm, d)
             end
         elseif min(d(:)) < 0
             i = d < 0;
-            a = (x0 - xmax)(i) ./ d(i);
+            a = (x0(i) - xmax(i)) ./ d(i);
             amin = min(amin, min(a));
             if amax < INF
                 amax = max(amax, max(a));
@@ -76,7 +76,7 @@ function [amin, amax] = optm_line_search_limits(x0, xmin, xmax, pm, d)
                 amax = INF;
             else
                 i = d < 0;
-                a = (xmin - x0)(i) ./ d(i);
+                a = (xmin(i) - x0(i)) ./ d(i);
                 amin = min(a);
                 amax = max(a);
             end
@@ -87,7 +87,7 @@ function [amin, amax] = optm_line_search_limits(x0, xmin, xmax, pm, d)
             end
         elseif max(d(:)) > 0
             i = d > 0;
-            a = (xmax - x0)(i) ./ d(i);
+            a = (xmax(i) - x0(i)) ./ d(i);
             amin = min(amin, min(a));
             if amax < INF
                 amax = max(amax, max(a));

--- a/matlab/src/optm_norm2.m
+++ b/matlab/src/optm_norm2.m
@@ -7,6 +7,6 @@
 function xnorm = optm_norm2(x)
     %%xnorm = norm(x(:), 2);
     %%xnorm = sqrt(x(:)'*x(:)); % <---- the fastest in an inlined function
-    %%xnorm = sqrt(sum(x(:).*x(:)));
-    xnorm = sqrt(sum((x.*x)(:))); % <-- the fastest in this context
+    xnorm = sqrt(sum(x(:).*x(:)));
+    %%xnorm = sqrt(sum((x.*x)(:))); % <-- the fastest in this context
 end


### PR DESCRIPTION
We have experienced troubles with a few functions because of incompatible Matlab syntaxes.

For example, the following instruction in the optm_INNER function :

`(x.*y)(:)`

 does not work and have to be replace by :

`x(:).*y(:)`

Another problem is that we can not require to access a specific element on an operation on 2 vectors "on-the-fly". For example, in the optm_lin_search_limits function :

`(x0 - xmin)(i)`

must become : 

`(x0(i) - xmin(i))`
